### PR TITLE
fix: import images parallely

### DIFF
--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -66,7 +66,7 @@ variable "powervs_private_subnet_2" {
 variable "powervs_public_network_enable" {
   description = "IBM Cloud PowerVS Public Network. Set to true to enable this."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "powervs_tags" {

--- a/modules/pi-workspace/README.md
+++ b/modules/pi-workspace/README.md
@@ -50,9 +50,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [ibm_pi_image.import_images_1](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_image) | resource |
-| [ibm_pi_image.import_images_2](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_image) | resource |
-| [ibm_pi_image.import_images_3](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_image) | resource |
+| [ibm_pi_image.import_images](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_image) | resource |
 | [ibm_pi_key.ssh_key](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_key) | resource |
 | [ibm_pi_network.private_subnet_1](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_network) | resource |
 | [ibm_pi_network.private_subnet_2](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_network) | resource |

--- a/modules/pi-workspace/pi_images.tf
+++ b/modules/pi-workspace/pi_images.tf
@@ -8,14 +8,11 @@ data "ibm_pi_catalog_images" "catalog_images_ds" {
 }
 
 locals {
-
   catalog_images_to_import = flatten([for stock_image in data.ibm_pi_catalog_images.catalog_images_ds.images : [for image_name in var.pi_image_names : stock_image if stock_image.name == image_name]])
-
 }
 
-
 #######################################################
-# Import of multiple images 
+# Import of multiple images
 #######################################################
 
 resource "ibm_pi_image" "import_images" {

--- a/modules/pi-workspace/pi_images.tf
+++ b/modules/pi-workspace/pi_images.tf
@@ -9,30 +9,20 @@ data "ibm_pi_catalog_images" "catalog_images_ds" {
 
 locals {
 
-  split_images_list = var.pi_image_names != null ? chunklist(var.pi_image_names, 2) : []
-  images_count      = length(local.split_images_list)
-
-  split_images_1 = (local.images_count > 0 ? toset(element(local.split_images_list, local.images_count - length(local.split_images_list))) : [])
-  split_images_2 = (length(local.split_images_1) > 0 && (local.images_count - 1) > 0 ? toset(element(local.split_images_list, (local.images_count - length(local.split_images_list)) + 1)) : [])
-  split_images_3 = (length(local.split_images_2) > 0 && (local.images_count - 2) > 0 ? toset(element(local.split_images_list, (local.images_count - length(local.split_images_list)) + 2)) : [])
-
-  catalog_images_to_import_1 = flatten([for stock_image in data.ibm_pi_catalog_images.catalog_images_ds.images : [for image_name in local.split_images_1 : stock_image if stock_image.name == image_name]])
-  catalog_images_to_import_2 = flatten([for stock_image in data.ibm_pi_catalog_images.catalog_images_ds.images : [for image_name in local.split_images_2 : stock_image if stock_image.name == image_name]])
-  catalog_images_to_import_3 = flatten([for stock_image in data.ibm_pi_catalog_images.catalog_images_ds.images : [for image_name in local.split_images_3 : stock_image if stock_image.name == image_name]])
+  catalog_images_to_import = flatten([for stock_image in data.ibm_pi_catalog_images.catalog_images_ds.images : [for image_name in var.pi_image_names : stock_image if stock_image.name == image_name]])
 
 }
 
 
 #######################################################
-# Using 3 resource blocks for import images as parallel
-# import of multiple images causes an error
+# Import of multiple images 
 #######################################################
 
-resource "ibm_pi_image" "import_images_1" {
+resource "ibm_pi_image" "import_images" {
 
-  for_each             = toset(local.split_images_1)
+  for_each             = toset(var.pi_image_names)
   pi_cloud_instance_id = ibm_resource_instance.pi_workspace.guid
-  pi_image_id          = local.catalog_images_to_import_1[index(tolist(local.split_images_1), each.key)].image_id
+  pi_image_id          = local.catalog_images_to_import[index((var.pi_image_names), each.key)].image_id
   pi_image_name        = each.key
 
   timeouts {
@@ -40,37 +30,12 @@ resource "ibm_pi_image" "import_images_1" {
   }
 }
 
-resource "ibm_pi_image" "import_images_2" {
-  depends_on           = [ibm_pi_image.import_images_1]
-  for_each             = toset(local.split_images_2)
-  pi_cloud_instance_id = ibm_resource_instance.pi_workspace.guid
-  pi_image_id          = local.catalog_images_to_import_2[index(tolist(local.split_images_2), each.key)].image_id
-  pi_image_name        = each.key
-
-  timeouts {
-    create = "9m"
-  }
-}
-
-resource "ibm_pi_image" "import_images_3" {
-  depends_on           = [ibm_pi_image.import_images_2]
-  for_each             = toset(local.split_images_3)
-  pi_cloud_instance_id = ibm_resource_instance.pi_workspace.guid
-  pi_image_id          = local.catalog_images_to_import_3[index(tolist(local.split_images_3), each.key)].image_id
-  pi_image_name        = each.key
-
-  timeouts {
-    create = "9m"
-  }
-}
 
 ################
 # For output
 ################
 
 locals {
-  import_images_1 = length(local.split_images_1) >= 1 ? { for image in ibm_pi_image.import_images_1 : image.pi_image_name => image.image_id } : null
-  import_images_2 = length(local.split_images_2) >= 1 ? { for image in ibm_pi_image.import_images_2 : image.pi_image_name => image.image_id } : null
-  import_images_3 = length(local.split_images_3) >= 1 ? { for image in ibm_pi_image.import_images_3 : image.pi_image_name => image.image_id } : null
-  pi_images       = merge(local.import_images_1, local.import_images_2, local.import_images_3)
+
+  pi_images = { for image in ibm_pi_image.import_images : image.pi_image_name => image.pi_image_id }
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.3
 
 require (
 	github.com/stretchr/testify v1.8.4
-	github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.23.12
+	github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.23.13
 )
 
 require (

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -662,8 +662,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.23.12 h1:xQm1vUcOT/Lsv7KPZcLrfIcLazEbF2Ot63y/8fz9+jk=
-github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.23.12/go.mod h1:47P+U6CO9RWNTWoYs5Ou8PatOL1X6lnrTySSgeO1+Bk=
+github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.23.13 h1:Ww7sc7R+lCQ9kDI8mdDfemgA4iy+EeN6tXRIS57VISw=
+github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.23.13/go.mod h1:47P+U6CO9RWNTWoYs5Ou8PatOL1X6lnrTySSgeO1+Bk=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmccombs/hcl2json v0.5.0 h1:cT2sXStOzKL06c8ZTf9vh+0N8GKGzV7+9RUaY5/iUP8=


### PR DESCRIPTION
### Description

Remove multiple import_images block and instead use 1 resource block to import images as storage team has eliminated the long copy of images and api calls are much simpler now

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
