### PR TITLE
fix: enable vtl images in catalog images

### DIFF
--- a/modules/pi-workspace/pi_images.tf
+++ b/modules/pi-workspace/pi_images.tf
@@ -3,8 +3,9 @@
 #####################################################
 
 data "ibm_pi_catalog_images" "catalog_images_ds" {
-  sap                  = true
   pi_cloud_instance_id = ibm_resource_instance.pi_workspace.guid
+  sap                  = true
+  vtl                  = true
 }
 
 locals {

--- a/tests/common-go-assets/cloudinfo-region-power-prefs.yaml
+++ b/tests/common-go-assets/cloudinfo-region-power-prefs.yaml
@@ -2,6 +2,6 @@
 - name: dal10
   useForTest: true
   testPriority: 1
-- name: mad04
+- name: mad02
   useForTest: true
   testPriority: 2

--- a/tests/common-go-assets/cloudinfo-region-power-prefs.yaml
+++ b/tests/common-go-assets/cloudinfo-region-power-prefs.yaml
@@ -2,6 +2,6 @@
 - name: dal10
   useForTest: true
   testPriority: 1
-- name: mad02
+- name: sao04
   useForTest: true
   testPriority: 2


### PR DESCRIPTION
### Description

added vtl=true for catalog images data source to list the vtl images

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
