### PR TITLE
fix: remove upper limit for required terraform version

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -16,7 +16,7 @@ An basic example that will provision the following:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.66.1 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.66.0 |
 
 ### Modules
 
@@ -29,7 +29,7 @@ An basic example that will provision the following:
 
 | Name | Type |
 |------|------|
-| [ibm_tg_gateway.transit_gateway](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.66.1/docs/resources/tg_gateway) | resource |
+| [ibm_tg_gateway.transit_gateway](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.66.0/docs/resources/tg_gateway) | resource |
 
 ### Inputs
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -15,8 +15,8 @@ An basic example that will provision the following:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.7 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.58.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.66.1 |
 
 ### Modules
 
@@ -29,7 +29,7 @@ An basic example that will provision the following:
 
 | Name | Type |
 |------|------|
-| [ibm_tg_gateway.transit_gateway](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/tg_gateway) | resource |
+| [ibm_tg_gateway.transit_gateway](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.66.1/docs/resources/tg_gateway) | resource |
 
 ### Inputs
 

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.66.1"
+      version = "=1.66.0"
     }
   }
 }

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -3,11 +3,11 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, < 1.7"
+  required_version = ">= 1.3"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.58.1"
+      version = "=1.66.1"
     }
   }
 }


### PR DESCRIPTION
### Description

remove upper limit for required terraform version

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
